### PR TITLE
Update Skunk from 0.5.1 => 0.6.0

### DIFF
--- a/modules/skunk/src/main/scala/SkunkCQRSRepository.scala
+++ b/modules/skunk/src/main/scala/SkunkCQRSRepository.scala
@@ -81,7 +81,7 @@ private final class SkunkCQRSRepository[F[_]: Clock, S, N](
         now <- currentTime[F]
         _ <- s
           .prepare(state.put)
-          .flatMap(_.execute(ctx.address ~ newState ~ version))
+          .flatMap(_.execute((ctx.address, newState, version)))
           .flatMap {
             case Completion.Insert(1) | Completion.Update(1) => F.unit
             case Completion.Insert(0) | Completion.Update(0) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
     val cats = "2.9.0"
     val catsEffect = "3.5.0"
     val fs2 = "3.7.0"
-    val skunk = "0.5.1"
+    val skunk = "0.6.0"
     val scalaCheck = "1.15.4"
     val MUnit = "1.0.0-M8"
     val CatsEffectMunit = "2.0.0-M3"


### PR DESCRIPTION
I noticed Scala Steward tried this in #161 & #163 but the jobs failed due to some [changes to twiddles in version 0.6.0](https://github.com/typelevel/skunk/pull/846)

Also updated some instances of `pmap` to `to` as the former has been deprecated