### PR TITLE
Fixed wrong snapshot usage

### DIFF
--- a/modules/backend/src/main/scala/eventsourcing/RepositoryReader.scala
+++ b/modules/backend/src/main/scala/eventsourcing/RepositoryReader.scala
@@ -54,10 +54,11 @@ object RepositoryReader {
           .flatMap {
             case Some(last) =>
               journal
-                .readStreamAfter(streamId, last.version)
+                .readStreamAfter(streamId, last.version - 1)
                 .through(scanState(last))
                 .compile
                 .lastOrError
+
             case None => history(streamId).compile.lastOrError
           }
 


### PR DESCRIPTION
This fixes a problem in snapshot usage which was slipped through!
This problem caused reading a wrong snapshot version if you used a cached repository.
It wasn't intended to behave like that, and I'm not sure if it was introduced by mindless refactoring, or I simply failed to notice.